### PR TITLE
NODE LOADS UI adjustment

### DIFF
--- a/public/node-loads.js
+++ b/public/node-loads.js
@@ -1,0 +1,74 @@
+(function main() {
+  const G = {}
+  loadToken(G)
+  G.monitorServerUrl = monitorServerUrl || `https://127.0.0.1:3000/api`
+  G.REFRESH_TIME = 10000
+
+  new Vue({
+      el: '#app',
+      data() {
+          return {
+              nodeLoads: [],
+              sortKey: 'ip',
+              sortAsc: true,
+          }
+      },
+      computed: {
+          sortedNodes() {
+              return this.nodeLoads.sort((a, b) => {
+                  let modifier = this.sortAsc ? 1 : -1
+                  if (a[this.sortKey] < b[this.sortKey]) return -1 * modifier
+                  if (a[this.sortKey] > b[this.sortKey]) return 1 * modifier
+                  return 0
+              })
+          },
+      },
+      methods: {
+          sortTable(key) {
+              if (this.sortKey === key) {
+                  this.sortAsc = !this.sortAsc
+              } else {
+                  this.sortKey = key
+                  this.sortAsc = true
+              }
+          },
+          async fetchChanges() {
+              let res = await requestWithToken(
+                  `${G.monitorServerUrl}/report?timestamp=${G.lastUpdatedTimestamp}`
+              )
+              return res.data
+          },
+          updateNetworkStatus(report) {
+              this.nodeLoads = []
+              for (let nodeId in report.nodes.active) {
+                  const node = report.nodes.active[nodeId]
+                  this.nodeLoads.push({
+                      id: nodeId,
+                      ip: node.nodeIpInfo.externalIp,
+                      port: node.nodeIpInfo.externalPort,
+                      loadInternal: node.currentLoad.nodeLoad.internal,
+                      loadExternal: node.currentLoad.nodeLoad.external,
+                      queueLength: node.queueLength,
+                      queueTime: node.txTimeInQueue,
+                  })
+              }
+          },
+          async updateNodes() {
+              try {
+                  let changes = await this.fetchChanges()
+                  this.updateNetworkStatus(changes)
+              } catch (e) {
+                  console.log('Error while trying to update nodes.', e)
+              }
+          },
+          start() {
+              this.updateNodes()
+              setInterval(this.updateNodes, G.REFRESH_TIME)
+          },
+      },
+      mounted() {
+          console.log('Mounted')
+          this.start()
+      },
+  })
+})()

--- a/views/large-network.html
+++ b/views/large-network.html
@@ -324,6 +324,9 @@
                 <tr id="itemrow">
                     <td><a href="/sync-details" target="_blank" class="text-sm text-blue-400">Sync Details</a></td>
                 </tr>
+                <tr id="itemrow">
+                    <td><a href="/node-loads" target="_blank" class="text-sm text-blue-400">Node Loads</a></td>
+                </tr>
             </table>
 
             <table id="montable">

--- a/views/node-loads.html
+++ b/views/node-loads.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Node Loads</title>
+    <script src="axios.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.6.14/dist/vue.js"></script>
+    <link href="https://unpkg.com/tailwindcss@^2/dist/tailwind.min.css" rel="stylesheet" />
+    <style>
+        body {
+            margin: 0;
+            background: #e0eafc;
+            background: -webkit-linear-gradient(to right, #cfdef3, #e0eafc);
+            background: linear-gradient(to right, #cfdef3, #e0eafc);
+            min-height: 100vh;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+        }
+
+        .center-container {
+            width: 100%;
+            max-width: 1200px; /* Adjust this value as needed */
+        }
+
+        .node-loads-container {
+            margin: 10px auto;
+            max-height: 90vh;
+            overflow: hidden;
+            font-family: sans-serif;
+            font-size: small;
+            font-weight: 300;
+            text-align: left;
+            background-color: #f3f4f6;
+            box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+        }
+
+        .table-wrapper {
+            overflow-x: auto;
+            max-height: calc(90vh - 30px);
+        }
+
+        .node-loads-container table {
+            width: 100%;
+            border-collapse: collapse;
+            white-space: nowrap;
+        }
+
+        .node-loads-container th,
+        .node-loads-container td {
+            padding: 5px;
+            text-align: left;
+            border: none;
+        }
+
+        .node-loads-container th {
+            background-color: #f3f4f6;
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            cursor: pointer;
+        }
+
+        .node-loads-container th:hover {
+            background-color: #e5e7eb;
+        }
+
+        /* Specific column widths */
+        .node-loads-container th:nth-child(1),
+        .node-loads-container td:nth-child(1) { width: 100px; } /* IP */
+        .node-loads-container th:nth-child(2),
+        .node-loads-container td:nth-child(2) { width: 60px; }  /* Port */
+        .node-loads-container th:nth-child(3),
+        .node-loads-container td:nth-child(3),
+        .node-loads-container th:nth-child(4),
+        .node-loads-container td:nth-child(4),
+        .node-loads-container th:nth-child(5),
+        .node-loads-container td:nth-child(5),
+        .node-loads-container th:nth-child(6),
+        .node-loads-container td:nth-child(6) { width: 100px; } /* Other columns */
+
+        @media (max-width: 1200px) {
+            .node-loads-container {
+                max-height: none;
+            }
+            .table-wrapper {
+                max-height: 90vh;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div id="app" class="center-container">
+        <div class="node-loads-container">
+            <div style="font-weight: bold; padding: 10px; background-color: #e5e7eb;">NODE LOADS</div>
+            <div class="table-wrapper">
+                <table class="table-auto w-full">
+                    <thead>
+                        <tr>
+                            <th @click="sortTable('ip')">IP</th>
+                            <th @click="sortTable('port')">Port</th>
+                            <th @click="sortTable('loadInternal')">Load Internal</th>
+                            <th @click="sortTable('loadExternal')">Load External</th>
+                            <th @click="sortTable('queueLength')">Q Length</th>
+                            <th @click="sortTable('queueTime')">Q Time</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="node in sortedNodes" :key="node.id">
+                            <td>{{ node.ip }}</td>
+                            <td>{{ node.port }}</td>
+                            <td>{{ node.loadInternal }}</td>
+                            <td>{{ node.loadExternal }}</td>
+                            <td>{{ node.queueLength }}</td>
+                            <td>{{ node.queueTime }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+
+    <script src="auth.js" type="text/javascript"></script>
+    <script src="node-loads.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Merge with this PR: https://github.com/shardeum/x-monitor-server/pull/14

Summary: 
 dedicated page for displaying node load information+
- Improved table layout for better responsiveness
- NODE LOADS now scrollable and on it's own row
![image](https://github.com/user-attachments/assets/88b128d8-bc7b-47f7-951e-fdb8a6793745)
![image](https://github.com/user-attachments/assets/dc36c1dd-bfea-4d62-96e7-e82f67dac6d1)
